### PR TITLE
[Date] Fix date creation with wrong timezone

### DIFF
--- a/src/Model/ArchivableInterface.php
+++ b/src/Model/ArchivableInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symandy\Component\Resource\Model;
 
 use DateTimeInterface;
+use DateTimeZone;
 
 interface ArchivableInterface
 {
@@ -13,7 +14,7 @@ interface ArchivableInterface
 
     public function setArchivedAt(?DateTimeInterface $archivedAt): void;
 
-    public function archive(): void;
+    public function archive(DateTimeZone $timezone = null): void;
 
     public function restore(): void;
 

--- a/src/Model/ArchivableTrait.php
+++ b/src/Model/ArchivableTrait.php
@@ -6,7 +6,9 @@ namespace Symandy\Component\Resource\Model;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 
+use function date_default_timezone_get;
 use function time;
 
 trait ArchivableTrait
@@ -24,9 +26,12 @@ trait ArchivableTrait
         $this->archivedAt = $archivedAt;
     }
 
-    public function archive(): void
+    public function archive(DateTimeZone $timezone = null): void
     {
-        $this->setArchivedAt(DateTimeImmutable::createFromFormat('U', (string) time()));
+        $timezone ??= new DateTimeZone(date_default_timezone_get());
+        $archivedAt = DateTimeImmutable::createFromFormat('U', (string) time());
+
+        $this->setArchivedAt($archivedAt->setTimezone($timezone));
     }
 
     public function restore(): void

--- a/src/Model/CreatableInterface.php
+++ b/src/Model/CreatableInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symandy\Component\Resource\Model;
 
 use DateTimeInterface;
+use DateTimeZone;
 
 interface CreatableInterface
 {
@@ -13,6 +14,6 @@ interface CreatableInterface
 
     public function setCreatedAt(?DateTimeInterface $createdAt): void;
 
-    public function create(): void;
+    public function create(DateTimeZone $timezone = null): void;
 
 }

--- a/src/Model/CreatableTrait.php
+++ b/src/Model/CreatableTrait.php
@@ -6,7 +6,9 @@ namespace Symandy\Component\Resource\Model;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 
+use function date_default_timezone_get;
 use function time;
 
 trait CreatableTrait
@@ -24,9 +26,12 @@ trait CreatableTrait
         $this->createdAt = $createdAt;
     }
 
-    public function create(): void
+    public function create(DateTimeZone $timezone = null): void
     {
-        $this->setCreatedAt(DateTimeImmutable::createFromFormat('U', (string) time()));
+        $timezone ??= new DateTimeZone(date_default_timezone_get());
+        $createdAt = DateTimeImmutable::createFromFormat('U', (string) time());
+
+        $this->setCreatedAt($createdAt->setTimezone($timezone));
     }
 
 }

--- a/src/Model/TimestampableTrait.php
+++ b/src/Model/TimestampableTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Symandy\Component\Resource\Model;
 
+use DateTimeZone;
+
 trait TimestampableTrait
 {
 
@@ -12,9 +14,9 @@ trait TimestampableTrait
     }
     use UpdatableTrait;
 
-    public function create(): void
+    public function create(DateTimeZone $timezone = null): void
     {
-        $this->initializeCreatedAt();
+        $this->initializeCreatedAt($timezone);
         $this->update();
     }
 

--- a/src/Model/UpdatableInterface.php
+++ b/src/Model/UpdatableInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symandy\Component\Resource\Model;
 
 use DateTimeInterface;
+use DateTimeZone;
 
 interface UpdatableInterface
 {
@@ -13,6 +14,6 @@ interface UpdatableInterface
 
     public function setUpdatedAt(?DateTimeInterface $updatedAt): void;
 
-    public function update(): void;
+    public function update(DateTimeZone $timezone = null): void;
 
 }

--- a/src/Model/UpdatableTrait.php
+++ b/src/Model/UpdatableTrait.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Symandy\Component\Resource\Model;
 
-use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 
+use function date_default_timezone_get;
 use function time;
 
 trait UpdatableTrait
@@ -25,9 +26,12 @@ trait UpdatableTrait
         $this->updatedAt = $updatedAt;
     }
 
-    public function update(): void
+    public function update(DateTimeZone $timezone = null): void
     {
-        $this->setUpdatedAt(DateTimeImmutable::createFromFormat('U', (string) time()));
+        $timezone ??= new DateTimeZone(date_default_timezone_get());
+        $updatedAt = DateTimeImmutable::createFromFormat('U', (string) time());
+
+        $this->setUpdatedAt($updatedAt->setTimezone($timezone));
     }
 
 }


### PR DESCRIPTION
## Description
After refactoring `DateTime` related trait (#8), the corresponding methods created datetime with the wrong timezone:
If the server was configured with timezone `Europe/Paris` (+01:00), the date was created with the timezone (+00:00).

This PR fixes this issue